### PR TITLE
Make Neptune work in other apps

### DIFF
--- a/Installation Files (no home indicator)/Neptune.plist
+++ b/Installation Files (no home indicator)/Neptune.plist
@@ -1,7 +1,7 @@
 {
 	Filter = {
 		Bundles = (
-			"com.apple.springboard",
+			"com.apple.UIKit",
 		);
 	};
 }

--- a/Installation Files/Neptune.plist
+++ b/Installation Files/Neptune.plist
@@ -1,7 +1,7 @@
 {
 	Filter = {
 		Bundles = (
-			"com.apple.springboard",
+			"com.apple.UIKit",
 		);
 	};
 }

--- a/Source/Neptune.plist
+++ b/Source/Neptune.plist
@@ -1,7 +1,7 @@
 {
 	Filter = {
 		Bundles = (
-			"com.apple.springboard",
+			"com.apple.UIKit",
 		);
 	};
 }


### PR DESCRIPTION
com.apple.springboard changed to com.apple.UIKit
Note: This requires being on the latest version of RootlessJB